### PR TITLE
Remove hiera gem prereq from install.rb

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -44,7 +44,7 @@ rescue LoadError
   $haverdoc = false
 end
 
-PREREQS = %w{openssl facter cgi hiera}
+PREREQS = %w{openssl facter cgi}
 MIN_FACTER_VERSION = 1.5
 
 InstallOptions = OpenStruct.new


### PR DESCRIPTION
The Hiera 3 gem should not be required anymore to install the agent, so it should not abort if it's absent.